### PR TITLE
Allow PR ref to be optional on dispatch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,6 @@
 ---
 name: Integration tests
-run-name: "ReRun PR #${{ inputs.pr }} - agent integration tests"
+run-name: "ReRun PR #${{ inputs.environment }} - agent integration tests"
 
 on:  #trunk-ignore(yamllint/truthy)
   workflow_call:
@@ -38,7 +38,6 @@ on:  #trunk-ignore(yamllint/truthy)
         type: string
       pr:
         description: Pass through github.event.pull_request.number
-        required: true
         type: string
 
 permissions:
@@ -284,6 +283,7 @@ jobs:
 
   deployment_bot_comment_test:
     name: Deployment Bot Comment - Test Complete
+    if: ${{ startsWith(inputs.environment, 'dev' )}}
     needs: [test]
     uses: resim-ai/workflows/.github/workflows/create-update-deployment-bot-comment.yml@v2
     with:


### PR DESCRIPTION
Switches the Run name to use the environment

Doesn't try to post a message on `main`

Part of https://app.asana.com/0/1207977581994839/1208550840208332/f