### PR TITLE
Bind mount root's docker config so we can read auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -262,6 +262,11 @@ func (a *Agent) runWorker(ctx context.Context, task Task, taskStateChan chan tas
 					Source: "/tmp/resim",
 					Target: "/tmp/resim",
 				},
+				{
+					Type:   mount.TypeBind,
+					Source: "/root/.docker",
+					Target: "/root/.docker",
+				},
 			},
 		},
 		&network.NetworkingConfig{},


### PR DESCRIPTION
The worker needs to read the local docker config so we can import auths for any registries we use on the host