### PR TITLE
Container Timeouts, DevContainer, Robustness Fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "image": "resimai/api-client:latest",
+    "initializeCommand": "docker pull --platform linux/amd64 resimai/api-client:latest",
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+        "source=root-home,target=/root,type=volume"
+    ],
+    "customizations": {
+        "vscode": {
+        "extensions": [
+            "42crunch.vscode-openapi",
+            "amazonwebservices.aws-toolkit-vscode",
+            "eamodio.gitlens",
+            "github.vscode-pull-request-github",
+            "golang.go",
+            "ms-azuretools.vscode-docker",
+            "ms-kubernetes-tools.vscode-kubernetes-tools"
+        ]
+        }
+    },
+    "remoteEnv": {
+        // localWorkspaceFolder is the host directory which is needed for volume mount commands from inside the container
+        "HOST_PROJECT_PATH": "${localWorkspaceFolder}"
+    }
+    }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Changes and release notes for the ReSim agent
 
+## v0.3.0 - 2025-02-19
+
+- Added support for experience-specific container timeouts
+
 ## v0.2.6 - 2025-01-21
 
 - Fixes missing parameter in integration test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Changes and release notes for the ReSim agent
 
-## v0.3.0 - 2025-02-19
+## v0.3.0 - 2025-02-20
 
 - Added support for experience-specific container timeouts
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sudo chgrp docker /run/containerd/containerd.sock
 
 ## Configuration
 
-By default, the Agent loads config from `~/resim/config.yaml`, caches credentials in that directory, and logs to the same directory (as well as `stdout`), however these settings can be overridden by setting the following environment variables:
+By default, the Agent loads config from `~/.resim/config.yaml`, caches credentials in that directory, and logs to the same directory (as well as `stdout`), however these settings can be overridden by setting the following environment variables:
 
 - `RESIM_AGENT_CONFIG_DIR` - to point to a different configuration and cache directory. The Agent will load configuration from `config.yaml` in this directory and cache credentials here.
 - `RESIM_AGENT_LOG_DIR` - to point to a different _directory_ in which to write log files
@@ -47,6 +47,16 @@ docker-network-mode: bridge
 ```
 
 Note that the `pool-labels` are an OR/ANY selection, that is, an agent running with the labels `big` and `small` will run jobs tagged with either of those labels.
+
+Note that to run in other ReSim environments, you can set the `api-host` and `auth-host` to the appropriate values for the environment you are targeting.
+
+## Building the agent
+
+```shell
+go build -o ./resim-agent ./
+```
+
+
 
 ## CI
 

--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -68,6 +68,7 @@ type TaskPollInput struct {
 
 // TaskPollOutput defines model for taskPollOutput.
 type TaskPollOutput struct {
+	ContainerTimeout           string                 `json:"containerTimeout"`
 	Tags                       *[]TagPair             `json:"tags,omitempty"`
 	TaskName                   *TaskName              `json:"taskName,omitempty"`
 	WorkerEnvironmentVariables *[]EnvironmentVariable `json:"workerEnvironmentVariables,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/resim-ai/api-client v0.3.8
+	github.com/resim-ai/api-client v0.5.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/mod v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/resim-ai/api-client v0.3.8 h1:HtM39RNXxQTmyCYYV/j89GefdF3KnMkmqvCealFTDO8=
-github.com/resim-ai/api-client v0.3.8/go.mod h1:AXe4yLII8PE7m3DLPetL+DiTu18S+aI22EzEMMyLNGU=
+github.com/resim-ai/api-client v0.5.0 h1:VmtrzMGhs4T1yNmBVO0dYmYgh25qy7eBVZkww0p1yF4=
+github.com/resim-ai/api-client v0.5.0/go.mod h1:wvlKfwYB6fBYdl5PZ7LdxjaHIjfEloBvLCEriYkLRmo=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const agentVersion = "v0.2.6"
+const agentVersion = "v0.3.0"
 
 type agentStatus string
 

--- a/main.go
+++ b/main.go
@@ -133,7 +133,6 @@ func (a *Agent) Start() error {
 		for {
 			select {
 			case taskStatusMessage := <-taskStateChan:
-				fmt.Println("Updating task status", "task_name", taskStatusMessage.Name, "status", taskStatusMessage.Status)
 				err := a.updateTaskStatus(ctx, taskStatusMessage.Name, taskStatusMessage.Status)
 				if err != nil {
 					slog.Error("Error updating task status", "err", err)

--- a/main.go
+++ b/main.go
@@ -281,6 +281,7 @@ func (a *Agent) runWorker(ctx context.Context, task Task, taskStateChan chan tas
 		"RERUN_WORKER_ENVIRONMENT=dev",
 		fmt.Sprintf("RERUN_WORKER_DOCKER_NETWORK_MODE=%v", a.DockerNetworkMode),
 		fmt.Sprintf("RERUN_WORKER_CONTAINER_TIMEOUT=%v", task.ContainerTimeout),
+		fmt.Sprintf("RERUN_WORKER_WORKER_ID=%v", a.Name),
 	}
 	if a.Privileged {
 		extraEnvVars = append(extraEnvVars, "RERUN_WORKER_PRIVILEGED=true")

--- a/main.go
+++ b/main.go
@@ -255,6 +255,7 @@ func (a *Agent) runWorker(ctx context.Context, task Task, taskStateChan chan tas
 	extraEnvVars := []string{
 		"RERUN_WORKER_ENVIRONMENT=dev",
 		fmt.Sprintf("RERUN_WORKER_DOCKER_NETWORK_MODE=%v", a.DockerNetworkMode),
+		fmt.Sprintf("RERUN_WORKER_CONTAINER_TIMEOUT=%v", task.ContainerTimeout),
 	}
 	if a.Privileged {
 		extraEnvVars = append(extraEnvVars, "RERUN_WORKER_PRIVILEGED=true")

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -24,14 +24,18 @@ ReRun as well. In that scenario, we'll pass across the appropriate test environm
 
 You can run these tests locally with a local running copy of the agent. Follow the instructions in the [main
 README](../../README.md) on how to configure the agent. You need to set a `pool-label` to something unique for your
-agent to pick up the test tasks.
+agent to pick up the test tasks. Almost certainly you will be running this in a different environment than the
+default, so you will need to set the `api-host` and `auth-host` to the appropriate values for the environment you are
+targeting.
 
 You need to create a container image for the local experience test. Simply build the `Dockerfile` in this directory and
 tag it, passing it into the test with the environment variable below. The `agent` assumes your docker daemon either has
 the image locally or is authenticated to the appropriate registry.
 
+Note that the ReSim app actively validates the image tag, so you need to have a full registry path.
+
 You will also need to obtain the password for the `e2e.resim.ai` account by [following these
-instructions](https://github.com/resim-ai/tf-auth0#cli-users). Note, this is a private repository.
+instructions](https://github.com/resim-ai/tf-auth0#agent-users). Note, this is a private repository.
 
 Set the following environment variables:
 
@@ -48,7 +52,7 @@ AGENT_TEST_PASSWORD=<the_password_you_obtained>
 AGENT_TEST_LOCAL_IMAGE=<your_test_build_image>
 ```
 
-Then run the following, and wait:
+Then run the following in a different terminal, and wait:
 
 ```shell
 go test -v ./test/integration

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -57,3 +57,5 @@ Then run the following in a different terminal, and wait:
 ```shell
 go test -v ./test/integration
 ```
+
+Note: if you are running this within the devcontainer, you will need to make sure there is a `/tmp/resim` directory on the host machine that the agent is running on and that the `.docker` directory is mounted into the container.

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -463,6 +463,7 @@ func (s *AgentTestSuite) createAndAwaitBatch(buildID uuid.UUID, experiences []uu
 
 	batch := *createBatchResponse.JSON201
 
+	s.T().Logf("Batch created, with ID: %v", *batch.BatchID)
 	s.Eventually(func() bool {
 		getResponse, err := s.APIClient.GetBatchWithResponse(
 			context.Background(),

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -108,7 +108,7 @@ func ListExpectedOutputFiles(realMetrics bool) []string {
 			fmt.Sprintf("metrics-%v", ExpectedExperienceNameBase64File),
 			"test_config.json",
 			"test_file.txt", // from an external file metric
-			"test.rrd",
+			"metrics-test.rrd",
 		}...)
 	}
 

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -332,7 +332,7 @@ func (s *AgentTestSuite) createS3TestExperience() {
 	s.s3Experiences = append(s.s3Experiences, createExperienceResponse.JSON201.ExperienceID)
 }
 
-func (s *AgentTestSuite) createLocalTestExperiences() {
+func (s *AgentTestSuite) createLocalTestExperiences(containerTimeout *int32) {
 	// Create an experience:
 	experienceName1 := "experience_1"
 	// experienceName2 := fmt.Sprintf("Test Experience %v", uuid.New())
@@ -345,6 +345,10 @@ func (s *AgentTestSuite) createLocalTestExperiences() {
 		Description: "description",
 		Location:    testLocation1,
 	}
+	if containerTimeout != nil {
+		createExperienceRequest.ContainerTimeoutSeconds = containerTimeout
+	}
+
 	createExperienceResponse, err := s.APIClient.CreateExperienceWithResponse(
 		context.Background(),
 		s.projectID,

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -96,6 +96,7 @@ func ListExpectedOutputFiles(realMetrics bool) []string {
 		ExpectedExperienceNameFile,
 		ExpectedExperienceNameBase64File,
 		"test_config.json",
+		"test.rrd",
 	}
 
 	if realMetrics {
@@ -107,6 +108,7 @@ func ListExpectedOutputFiles(realMetrics bool) []string {
 			fmt.Sprintf("metrics-%v", ExpectedExperienceNameBase64File),
 			"test_config.json",
 			"test_file.txt", // from an external file metric
+			"test.rrd",
 		}...)
 	}
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -179,7 +179,7 @@ func (s *AgentTestSuite) TestDockerAgentWithS3Experience() {
 // Test the agent with a batch where the experiences timeout is tiny and should error
 func (s *AgentTestSuite) TestAgentWithZeroExperienceTimeout() {
 	realMetrics := false
-	s.createLocalTestExperiences(Ptr(int32(10)))
+	s.createLocalTestExperiences(Ptr(int32(0)))
 	batch := s.createAndAwaitBatch(s.buildIDLocal, s.localExperiences, false, realMetrics)
 	s.Equal(batch.Status, api.BatchStatusERROR)
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -175,11 +175,3 @@ func (s *AgentTestSuite) TestDockerAgentWithS3Experience() {
 		}
 	}
 }
-
-// Test the agent with a batch where the experiences timeout is tiny and should error
-func (s *AgentTestSuite) TestAgentWithZeroExperienceTimeout() {
-	realMetrics := false
-	s.createLocalTestExperiences(Ptr(int32(0)))
-	batch := s.createAndAwaitBatch(s.buildIDLocal, s.localExperiences, false, realMetrics)
-	s.Equal(batch.Status, api.BatchStatusERROR)
-}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -97,7 +97,7 @@ func (s *AgentTestSuite) TestAgentWithS3Experience() {
 // Test the agent with a batch where the experiences are baked into the image
 func (s *AgentTestSuite) TestAgentWithLocalExperience() {
 	realMetrics := false
-	s.createLocalTestExperiences()
+	s.createLocalTestExperiences(nil)
 	batch := s.createAndAwaitBatch(s.buildIDLocal, s.localExperiences, false, realMetrics)
 	jobsResponse, err := s.APIClient.ListJobsWithResponse(
 		context.Background(),
@@ -174,4 +174,12 @@ func (s *AgentTestSuite) TestDockerAgentWithS3Experience() {
 			}
 		}
 	}
+}
+
+// Test the agent with a batch where the experiences timeout is tiny and should error
+func (s *AgentTestSuite) TestAgentWithZeroExperienceTimeout() {
+	realMetrics := false
+	s.createLocalTestExperiences(Ptr(int32(10)))
+	batch := s.createAndAwaitBatch(s.buildIDLocal, s.localExperiences, false, realMetrics)
+	s.Equal(batch.Status, api.BatchStatusERROR)
 }


### PR DESCRIPTION
# Description

The primary contribution of this PR is to introduce container timeouts to the agent. Along the way it:

 - Updates the documentation for running the agent and integration test
 - Fixes a problem with the agent itself updating statuses
 - Sets the agent id as the worker id to enable the worker to report correctly
 - Fixes situations where the agent can fail, but not update the status or its internal heartbeat status
 - Adds a devcontainer
 
# Agent PR Checklist

- [X] Have you bumped the version number in main.go?
- [X] Have you updated CHANGELOG.md?