### PR TITLE
Tell agent integration test to expect resource_metrics.binproto

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -90,7 +90,7 @@ func ListExpectedOutputFiles(realMetrics bool) []string {
 	expectedOutputFiles := []string{
 		TestMCAPFile,
 		TestMP4File,
-		"metrics.binproto",
+		"resource_metrics.binproto",
 		"experience-worker.log",
 		"experience-container.log",
 		"metrics-worker.log",


### PR DESCRIPTION
# Agent PR Checklist

- Have you bumped the version number in main.go?
- Have you updated CHANGELOG.md?

No; it's just an integration test fix.