### PR TITLE
make the instance used for integration tests use gp3

### DIFF
--- a/test/integration/instance.tf
+++ b/test/integration/instance.tf
@@ -99,6 +99,10 @@ resource "aws_instance" "test_agent" {
   }
 
   user_data = data.cloudinit_config.config.rendered
+
+  root_block_device {
+    volume_type = "gp3"
+  }
 }
 
 resource "aws_iam_policy" "this" {


### PR DESCRIPTION
# Agent PR Checklist

- Have you bumped the version number in main.go?
- Have you updated CHANGELOG.md?

^ neither of the above is relevant, this just tells the integration test instances to use GP3.