### PR TITLE
WOB-4360 | Expect resource/test-length Metrics-2 emissions in e2e output

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -105,6 +105,10 @@ func ListExpectedOutputFiles(realMetrics bool) []string {
 		TestMCAPFile,
 		TestMP4File,
 		"resource_metrics.binproto",
+		// Metrics 2.0 resource/test-length emissions (workers/docker_metrics.go
+		// in the rerun repo).
+		"resource_metrics.resim.jsonl",
+		"test_length_metric.resim.jsonl",
 		"experience-worker.log",
 		"experience-container.log",
 		"metrics-worker.log",


### PR DESCRIPTION
# Agent PR Checklist

- Have you bumped the version number in main.go? No -- this is a test-expectations-only change, no behavior change to the agent binary itself.
- Have you updated CHANGELOG.md? No, for the same reason.

## Description of change

The `rerun` worker (used both in Kubernetes and in ECS/Agent mode, including this repo's Docker-outside-of-Docker launch path) now writes `resource_metrics.resim.jsonl` and `test_length_metric.resim.jsonl` for Metrics 2.0 -- previously only Kubernetes-mode jobs produced these files (see rerun PR for the actual worker change). This adds both to `ListExpectedOutputFiles` so the agent's e2e suite (`TestAgentWithS3Experience` et al.) actually asserts on them.

Companion rerun-repo PR: (link once opened)

Ticket: WOB-4360