### PR TITLE
WOB-4172 | Drop resource_metrics.binproto from e2e expected output

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -104,9 +104,8 @@ func ListExpectedOutputFiles(realMetrics bool) []string {
 	expectedOutputFiles := []string{
 		TestMCAPFile,
 		TestMP4File,
-		"resource_metrics.binproto",
-		// Metrics 2.0 resource/test-length emissions (workers/docker_metrics.go
-		// in the rerun repo).
+		// Resource/test-length emissions (workers/docker_metrics.go in the
+		// rerun repo).
 		"resource_metrics.resim.jsonl",
 		"test_length_metric.resim.jsonl",
 		"experience-worker.log",


### PR DESCRIPTION
# Description of change

The rerun worker no longer writes the Metrics-1 `resource_metrics.binproto`. It now emits only the JSON-Lines forms, `resource_metrics.resim.jsonl` and `test_length_metric.resim.jsonl`, which this list already expects.

The agent has no metrics logic of its own — the daemon launches the same `workers` binary from the rerun repo via the Docker-outside-of-Docker pattern, so this expected-output list is the only coupling. Because the e2e asserts an *exact* file set, it has to drop the binproto in lockstep with the rerun change.

## Ordering

Companion to resim-ai/rerun#3783. That PR must land first; merge this immediately after, so the agent e2e on main is never expecting a file the worker no longer writes.

To validate before then, run the agent e2e against rerun#3783's image tag via the `ImageTagKey` viper setting (`--image-tag 3783`).

Ticket: WOB-4172
